### PR TITLE
Delete docs/runners_manual_2021/historical_information directory

### DIFF
--- a/docs/runners_manual_2021/historical_information/historical_information.md
+++ b/docs/runners_manual_2021/historical_information/historical_information.md
@@ -1,9 +1,0 @@
----
-layout: default
-title: Historical Information
-parent: Runners Manual 2021
-nav_order: 3
-has_children: true
----
-
-# Part 3: Historical Information


### PR DESCRIPTION
Deprecated section of the manual, to be replaced by links to relevant tables via OST or elsewhere on the main hardrock100.com